### PR TITLE
Create pt-BR.json - Brazilian Portuguese translation

### DIFF
--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1,0 +1,99 @@
+{
+    "form": {
+        "title": "Fatura",
+        "description": "Gerar Fatura",
+        "newInvBadge": "Nova Fatura",
+        "wizard": {
+            "fromAndTo": "De & Para",
+            "invoiceDetails": "Detalhes da Fatura",
+            "lineItems": "Itens",
+            "paymentInfo": "Informações de Pagamento",
+            "summary": "Resumo",
+            "next": "Próximo",
+            "back": "Voltar"
+        },
+        "steps": {
+            "fromAndTo": {
+                "billFrom": "Emitido Por",
+                "billTo": "Faturado Para",
+                "name": "Nome",
+                "namePlaceholder": "Seu nome",
+                "address": "Endereço",
+                "addressPlaceholder": "Seu endereço",
+                "zipCode": "CEP",
+                "zipCodePlaceholder": "Seu CEP",
+                "city": "Cidade",
+                "cityPlaceholder": "Sua cidade",
+                "country": "País",
+                "countryPlaceholder": "Seu país",
+                "email": "Email",
+                "emailPlaceholder": "Seu email",
+                "phone": "Telefone",
+                "phonePlaceholder": "Seu telefone",
+                "addCustomInput": "Adicionar Campo Personalizado",
+                "sender": "Remetente",
+                "receiver": "Destinatário"
+            },
+            "invoiceDetails": {
+                "heading": "Detalhes da Fatura",
+                "invoiceLogo": {
+                    "label": "Logo da Fatura",
+                    "placeholder": "Clique para fazer upload da imagem"
+                },
+                "invoiceNumber": "Número da Fatura",
+                "issuedDate": "Data de Emissão",
+                "dueDate": "Data de Vencimento",
+                "currency": "Moeda"
+            },
+            "lineItems": {
+                "heading": "Itens",
+                "item": "Item",
+                "name": "Nome",
+                "quantity": "Quantidade",
+                "rate": "Taxa",
+                "total": "Total",
+                "description": "Descrição",
+                "addNewItem": "Adicionar um novo item",
+                "removeItem": "Remover item"
+            },
+            "paymentInfo": {
+                "heading": "Informações de Pagamento",
+                "bankName": "Nome do Banco",
+                "accountName": "Nome da Conta",
+                "accountNumber": "Número da Conta"
+            },
+            "summary": {
+                "heading": "Resumo",
+                "signature": {
+                    "heading": "Assinatura",
+                    "placeholder": "Clique para adicionar assinatura",
+                    "draw": "Desenhar",
+                    "type": "Digitar",
+                    "upload": "Fazer upload"
+                },
+                "additionalNotes": "Notas Adicionais",
+                "paymentTerms": "Condições de Pagamento",
+                "discount": "Desconto",
+                "tax": "Imposto",
+                "shipping": "Frete",
+                "subTotal": "Subtotal",
+                "totalAmount": "Valor Total",
+                "includeTotalInWords": "Incluir Total por Extenso?",
+                "yes": "Sim",
+                "no": "Não"
+            }
+        }
+    },
+    "actions": {
+        "title": "Ações",
+        "description": "Operações e visualização",
+        "loadInvoice": "Carregar Fatura",
+        "exportInvoice": "Exportar Fatura",
+        "newInvoice": "Nova Fatura",
+        "generatePdf": "Gerar PDF",
+        "pdfView": "Visualização em PDF"
+    },
+    "footer": {
+        "developedBy": "Desenvolvido por"
+    }
+}

--- a/lib/variables.ts
+++ b/lib/variables.ts
@@ -53,12 +53,14 @@ export const NODEMAILER_PW = process.env.NODEMAILER_PW;
  * I18N
  */
 export const LOCALES = [
-  { code: "en", name: "English" },
-  { code: "de", name: "Deutsch" },
-  { code: "it", name: "Italiano" },
-  { code: "es", name: "Español" },
-  { code: "fr", name: "Français" },
-  { code: "ar", name: "العربية" },]
+    { code: "en", name: "English" },
+    { code: "de", name: "Deutsch" },
+    { code: "it", name: "Italiano" },
+    { code: "es", name: "Español" },
+    { code: "fr", name: "Français" },
+    { code: "ar", name: "العربية" },
+    { code: "pt-BR", name: "Português (Brasil)" },
+]
 export const DEFAULT_LOCALE = LOCALES[0].code;
 
 /**


### PR DESCRIPTION
This adds support for base Brazilian Portuguese translation.
pt-BR.json was created and "Português (Brasil)" was added to the locale selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a fully localized interface for invoice management in Brazilian Portuguese, enhancing user experience for Portuguese-speaking users.
	- Expanded language options by adding Portuguese (Brazil) to the available locales in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->