### PR TITLE
Allow multi-line formatting in the line item description

### DIFF
--- a/app/components/templates/invoice-pdf/InvoiceTemplate1.tsx
+++ b/app/components/templates/invoice-pdf/InvoiceTemplate1.tsx
@@ -115,7 +115,7 @@ const InvoiceTemplate = (data: InvoiceType) => {
                                     <p className="font-medium text-gray-800">
                                         {item.name}
                                     </p>
-                                    <p className="text-xs text-gray-600">
+                                    <p className="text-xs text-gray-600 whitespace-pre-line">
                                         {item.description}
                                     </p>
                                 </div>

--- a/app/components/templates/invoice-pdf/InvoiceTemplate2.tsx
+++ b/app/components/templates/invoice-pdf/InvoiceTemplate2.tsx
@@ -115,7 +115,7 @@ const InvoiceTemplate2 = (data: InvoiceType) => {
                                     <p className="font-medium text-gray-800">
                                         {item.name}
                                     </p>
-                                    <p className="text-xs text-gray-600">
+                                    <p className="text-xs text-gray-600 whitespace-pre-line">
                                         {item.description}
                                     </p>
                                 </div>


### PR DESCRIPTION
Line items in the pdf template should display exactly as input in the form (in my opinion)

Love the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced formatting of item descriptions in invoice templates to preserve whitespace and line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->