### PR TITLE
Fix form layout issue when field is empty and 'Generate PDF' is clicked (#614)

### DIFF
--- a/app/components/invoice/InvoiceForm.tsx
+++ b/app/components/invoice/InvoiceForm.tsx
@@ -73,7 +73,7 @@ const InvoiceForm = () => {
                     <div className="space-y-8">
                         <Wizard>
                             <WizardStep>
-                                <div className="flex flex-wrap gap-x-20 gap-y-10">
+                                <div className="flex gap-x-20 gap-y-10">
                                     <BillFromSection />
 
                                     <BillToSection />

--- a/app/components/reusables/form-fields/FormInput.tsx
+++ b/app/components/reusables/form-fields/FormInput.tsx
@@ -63,13 +63,13 @@ const FormInput = ({
             name={name}
             render={({ field }) => (
                 <FormItem>
-                    <div className="flex justify-between gap-5 items-center text-sm">
-                        {label && <FormLabel>{`${label}:`}</FormLabel>}
+                    <div className="flex w-full gap-5 items-center text-sm">
+                        {label && <FormLabel className="flex-1">{`${label}:`}</FormLabel>}
                         {labelHelper && (
                             <span className="text-xs"> {labelHelper}</span>
                         )}
 
-                        <div>
+                        <div className="flex-1">
                             <FormControl>
                                 <Input
                                     {...field}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/811e122f-8701-47a7-a467-448dcab3e71e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the invoice form layout by adjusting the container behavior to maintain a consistent, non-wrapping display.
  - Enhanced the form input visuals by optimizing spacing and enabling a full-width layout for more balanced alignment of labels and fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->