### PR TITLE
Fixes Phone Input Validation Mismatch

### DIFF
--- a/app/components/invoice/form/sections/BillFromSection.tsx
+++ b/app/components/invoice/form/sections/BillFromSection.tsx
@@ -79,7 +79,7 @@ const BillFromSection = () => {
                 placeholder="Your phone number"
                 type="text"
                 inputMode="tel"
-                pattern="[0-9]*"
+                pattern="[0-9+\-\(\)\s]*"
                 aria-describedby="phone-format"
                 onInput={(e) => {
                     const target = e.target as HTMLInputElement;

--- a/app/components/invoice/form/sections/BillToSection.tsx
+++ b/app/components/invoice/form/sections/BillToSection.tsx
@@ -80,7 +80,7 @@ const BillToSection = () => {
                 placeholder="Receiver phone number"
                 type="text"
                 inputMode="tel"
-                pattern="[0-9]*"
+                pattern="[0-9+\-\(\)\s]*"
                 aria-describedby="phone-format"
                 onInput={(e) => {
                     const target = e.target as HTMLInputElement;


### PR DESCRIPTION
### Issue Reference  
Fixes #632 

This PR updates the `pattern` attribute for the phone number input to align with the characters allowed by the `onInput` handler. Previously, `pattern="[0-9]*"` only permitted digits, causing validation errors when users entered `+`, `-`, `(`, `)`, or spaces.  

#### **Changes:**  
- Updated `pattern` to:  
  ```tsx
  pattern="[0-9+\-\(\)\s]*"
  ```  
- Ensured consistency between input validation and the allowed format.  

#### **Testing:**  
- Enter various phone number formats, including `+1 (123) 456-7890`, and confirm no validation errors occur.  
- Verify that invalid characters are still removed on input.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced phone number input fields on invoice forms to support a broader range of characters, including digits, plus signs, hyphens, parentheses, and whitespace. This update improves flexibility, allowing users to enter phone numbers in various international formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->