### PR TITLE
feat: Add addressLine2 and reorder address fields

### DIFF
--- a/app/components/invoice/form/sections/BillFromSection.tsx
+++ b/app/components/invoice/form/sections/BillFromSection.tsx
@@ -54,14 +54,19 @@ const BillFromSection = () => {
                 placeholder="Your address"
             />
             <FormInput
-                name="sender.zipCode"
-                label={_t("form.steps.fromAndTo.zipCode")}
-                placeholder="Your zip code"
+                name="sender.addressLine2"
+                label={_t("form.steps.fromAndTo.addressLine2")}
+                placeholder="Apartment, suite, etc. (Optional)"
             />
             <FormInput
                 name="sender.city"
                 label={_t("form.steps.fromAndTo.city")}
                 placeholder="Your city"
+            />
+            <FormInput
+                name="sender.zipCode"
+                label={_t("form.steps.fromAndTo.zipCode")}
+                placeholder="Your zip code"
             />
             <FormInput
                 name="sender.country"

--- a/app/components/invoice/form/sections/BillToSection.tsx
+++ b/app/components/invoice/form/sections/BillToSection.tsx
@@ -55,14 +55,19 @@ const BillToSection = () => {
                 placeholder="Receiver address"
             />
             <FormInput
-                name="receiver.zipCode"
-                label={_t("form.steps.fromAndTo.zipCode")}
-                placeholder="Receiver zip code"
+                name="receiver.addressLine2"
+                label={_t("form.steps.fromAndTo.addressLine2")}
+                placeholder="Apartment, suite, etc. (Optional)"
             />
             <FormInput
                 name="receiver.city"
                 label={_t("form.steps.fromAndTo.city")}
                 placeholder="Receiver city"
+            />
+            <FormInput
+                name="receiver.zipCode"
+                label={_t("form.steps.fromAndTo.zipCode")}
+                placeholder="Receiver zip code"
             />
             <FormInput
                 name="receiver.country"

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -89,6 +89,7 @@ const CustomInputSchema = z.object({
 const InvoiceSenderSchema = z.object({
     name: fieldValidators.name,
     address: fieldValidators.address,
+    addressLine2: fieldValidators.stringOptional,
     zipCode: fieldValidators.zipCode,
     city: fieldValidators.city,
     country: fieldValidators.country,
@@ -100,6 +101,7 @@ const InvoiceSenderSchema = z.object({
 const InvoiceReceiverSchema = z.object({
     name: fieldValidators.name,
     address: fieldValidators.address,
+    addressLine2: fieldValidators.stringOptional,
     zipCode: fieldValidators.zipCode,
     city: fieldValidators.city,
     country: fieldValidators.country,

--- a/lib/variables.ts
+++ b/lib/variables.ts
@@ -120,6 +120,7 @@ export const FORM_DEFAULT_VALUES = {
     sender: {
         name: "",
         address: "",
+        addressLine2: "",
         zipCode: "",
         city: "",
         country: "",
@@ -130,6 +131,7 @@ export const FORM_DEFAULT_VALUES = {
     receiver: {
         name: "",
         address: "",
+        addressLine2: "",
         zipCode: "",
         city: "",
         country: "",


### PR DESCRIPTION
- Adds an optional `addressLine2` field to both sender and receiver address forms.
- Updates Zod schemas, TypeScript types (implicitly via schema inference), and default form values to include `addressLine2`.
- Modifies the UI in `BillFromSection.tsx` and `BillToSection.tsx` to include the new `addressLine2` input field.
- Reorders the `zipCode` field to appear below the `city` field in both sender and receiver address forms for improved layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional "Apartment, suite, etc." address line field to both sender and receiver sections in the invoice form.

- **Style**
  - Updated the order of address fields in the invoice form, moving the zip code input below the city input for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->