### PR TITLE
fix: :bug: update item quantity validator to use .gt() and 0 for greater than comparison

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -51,7 +51,7 @@ const fieldValidators = {
     // Items
     quantity: z.coerce
         .number()
-        .min(1, { message: "Must be a number greater than 0" }),
+        .gt(0, { message: "Must be a number greater than 0" }),
     unitPrice: z.coerce
         .number()
         .gt(0, { message: "Must be a number greater than 0" })


### PR DESCRIPTION
The item quantity used `min`, which is an alias to `gte`. However, the message indicated `Must be a number greater than 0` but in reality the quantity had to be greater or equal to 1. I updated the validator to use `gt` and 0, since a quantity can be lower than one as long as it is greater than 0, e.g. with hourly rate or real world units.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for quantity fields to ensure only numbers greater than 0 are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->