### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/services/invoice/server/generatePdfService.ts
+++ b/services/invoice/server/generatePdfService.ts
@@ -80,7 +80,7 @@ export async function generatePdfService(req: NextRequest) {
 	} catch (error: any) {
 		console.error("PDF Generation Error:", error);
 		return new NextResponse(
-			JSON.stringify({ error: "Failed to generate PDF", details: { message: error?.message, stack: error?.stack } }),
+			JSON.stringify({ error: "Failed to generate PDF" }),
 			{
 				status: 500,
 				headers: {


### PR DESCRIPTION
Potential fix for [https://github.com/al1abb/invoify/security/code-scanning/2](https://github.com/al1abb/invoify/security/code-scanning/2)

To fix this issue, you should avoid including the stack trace (and potentially detailed error messages) in the response sent to the client. Instead, send a generic error message to the client while logging the full details, including stack trace, server-side for debugging purposes. This change should be made in the catch block, specifically where the response is constructed (line 83). You should only send a generic error string (e.g., "Failed to generate PDF") while ensuring that `error?.stack` and potentially sensitive details are omitted from the response but retained in server logs via `console.error`. 

No extra imports are needed for logging with `console.error`. Only the block preparing the error response should be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized PDF generation error responses to a generic message, avoiding exposure of internal details.
  * Status codes and headers remain unchanged; successful flows are unaffected.
  * Improves failure safety and provides a cleaner, more consistent API contract for clients.
  * No changes to public interfaces or successful response schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->